### PR TITLE
parseName 로직 간소화

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -8,14 +8,14 @@ function getRegexValue(regex: RegExp, str: string) {
 }
 
 export function parseName(nameStr: string) {
-    const weightRegex = /(\/\d+)/;
-    const countRegex = /(\*\d+)/;
+    const weightRegex = /\/(\d+)/;
+    const countRegex = /\*(\d+)/;
     const hasWeight = weightRegex.test(nameStr);
     const hasCount = countRegex.test(nameStr);
     const name = getRegexValue(/^\s*([^\/*]+)?/, nameStr);
     if (!name) return null;
-    const weight = hasWeight ? parseInt(getRegexValue(weightRegex, nameStr).replace('/', '')) : 1;
-    const count = hasCount ? parseInt(getRegexValue(countRegex, nameStr).replace('*', '')) : 1;
+    const weight = hasWeight ? parseInt(getRegexValue(weightRegex, nameStr)) : 1;
+    const count = hasCount ? parseInt(getRegexValue(countRegex, nameStr)) : 1;
     return {
         name,
         weight,


### PR DESCRIPTION
count와 weight의 정규표현식 그룹 범위를 조정하면 replace 과정을 생략할 수 있습니다.