### PR TITLE
Updated index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,12 @@
   <meta name="msapplication-TileImage" content="assets/ms-icon-144x144.png">
   <meta name="theme-color" content="#ffffff">
   <title>Marble Roulette</title>
+  <meta name="description" content="A lucky draw by dropping marbles, made by lazygyu">
+  <meta property="og:url" content="https://lazygyu.github.io/roulette/">
+  <meta property="og:title" content="Marble Roulette">
+  <meta property="og:description" content="A lucky draw by dropping marbles, made by lazygyu">
+  <meta property="og:site_name" content="lazygyu.github.io">
+  <meta property="og:type" content="website">
   <style lang="scss">
     * {
       box-sizing: border-box;


### PR DESCRIPTION
1. 대한변협법률구조재단 a태그에 링크가 빠져있어서 추가하였습니다.
2. 현재 마블 룰렛 사이트를 구글에 검색시 아래와 같이 표시되고 있습니다. 이를 개선하기 위해 메타 태그를 추가하였습니다.
<img width="727" height="142" alt="image" src="https://github.com/user-attachments/assets/d3cb6319-adc3-46d0-95fe-e8b3db959861" />

---
저작권 관련해 좋은 소식 있기를 응원드립니다.