### PR TITLE
feat: Allow names to be loaded from URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,9 +119,16 @@
     }
     console.log('initializing start');
 
-    const savedNames = localStorage.getItem('mbr_names');
-    if (savedNames) {
-      document.querySelector('#in_names').value = savedNames;
+    const urlParams = new URLSearchParams(window.location.search);
+    const namesFromUrl = urlParams.get('names');
+
+    if (namesFromUrl) {
+      document.querySelector('#in_names').value = namesFromUrl.replace(/,/g, '\n');
+    } else {
+      const savedNames = localStorage.getItem('mbr_names');
+      if (savedNames) {
+        document.querySelector('#in_names').value = savedNames;
+      }
     }
     document.querySelector('#in_names').addEventListener('input', () => {
       getReady();


### PR DESCRIPTION
This commit introduces the ability to pre-populate the names input field using a 'names' query parameter in the URL.
If the 'names' parameter is present, its value will be used, overriding any names saved in localStorage.
If no 'names' parameter is found, the system will fall back to using names stored in localStorage.

Usage
To use this feature, append `?names=name1,name2,name3` to the URL.
For example: https://lazygyu.github.io/roulette/?names=짱구,짱아,봉미선