### PR TITLE
fix ui layout at safari browser

### DIFF
--- a/assets/style.scss
+++ b/assets/style.scss
@@ -211,6 +211,8 @@ div.copyright a {
 
       .toggle-item {
         width: 50%;
+        display: flex;
+        align-items: center;
       }
     }
   }


### PR DESCRIPTION
macos의 safari에서 좌측하단 UI 이상하게 나오는 문제를 수정합니다. #56 

수정 후

<img width="699" height="179" alt="스크린샷 2026-04-17 오후 8 02 32" src="https://github.com/user-attachments/assets/38c381d8-0fb3-4faa-a52a-7101e29802a6" />
