### PR TITLE
게임 시작 시 선택된 맵을 umami로 추적

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,11 @@
         return { name: p.name, count: p.count };
       });
       if (typeof umami !== 'undefined') {
-        umami.track('start', { count: window.roulette.getCount() });
+        const currentMap = window.roulette.getCurrentMap();
+        umami.track('start', {
+          count: window.roulette.getCount(),
+          map: currentMap ? currentMap.title : 'unknown',
+        });
         marbles.forEach(m => {
           umami.track('marble', { name: m.name, count: m.count });
         });

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -442,6 +442,14 @@ export class Roulette extends EventTarget {
     });
   }
 
+  public getCurrentMap() {
+    if (!this._stage) return null;
+    return {
+      index: stages.indexOf(this._stage),
+      title: this._stage.title,
+    };
+  }
+
   public setMap(index: number) {
     if (index < 0 || index > stages.length - 1) {
       throw new Error('Incorrect map number');


### PR DESCRIPTION
## 배경

umami로 `start`(구슬 개수), `marble`(이름/개수) 이벤트를 보내고 있었지만 **어떤 맵으로 시작했는지**는 기록하지 않아 맵별 인기도를 알 수 없었다.

## 변경 사항

- `Roulette.getCurrentMap()` 추가 — 현재 선택된 스테이지의 `{ index, title }` 반환. 기존에는 `getMaps()`/`setMap()`만 있고 조회 API가 없었다.
- `index.html`의 시작 버튼 핸들러에서 umami `start` 이벤트에 `map` 속성 추가.

별도 이벤트를 만드는 대신 `start`의 속성으로 넣어, 총 시작 횟수 대비 맵별 비율을 그대로 볼 수 있게 했다. gtag(GA)는 건드리지 않았다.

### 왜 DOM 텍스트가 아니라 소스의 영문 title인가

`<option>` 텍스트는 `translateElement()`로 현지화되므로 DOM에서 읽으면 언어별로 다른 값이 집계된다. 실제로 `Yoru ni Kakeru` 맵은 영어 로케일에서도 `Into The Night (by item4)`로 표시된다.

## 검증

헤드리스 Chrome으로 4개 맵을 각각 시작시켜 `umami.track` 페이로드를 캡처했다. (실서비스 오염 방지를 위해 `umami.lazygyu.net` 요청은 차단하고 `window.umami`를 스텁으로 대체)

| 맵 선택 | select 표시 텍스트 | 전송된 `map` 값 |
|---|---|---|
| index 0 | Wheel of fortune | `Wheel of fortune` |
| index 1 | BubblePop | `BubblePop` |
| index 2 | Pot of greed | `Pot of greed` |
| index 3 | Into The Night (by item4) | `Yoru ni Kakeru` |
| index 2 (ko-KR) | 욕망의 항아리 | `Pot of greed` |

- `setMap(2)` 후 `getCurrentMap()`이 `{ index: 2, title: 'Pot of greed' }`로 갱신되는 것 확인
- `yarn lint` 통과

umami 대시보드에서 Events → `start` → Properties 에서 맵별 분포를 확인할 수 있다.