### PR TITLE
feat) 광고 소재를 슬롯별로 분리

### DIFF
--- a/src/adRenderer.ts
+++ b/src/adRenderer.ts
@@ -19,7 +19,10 @@ export interface AdOverlayState {
 }
 
 export interface AdImages {
-  square?: HTMLImageElement;
+  /** 프리롤 카드에 들어가는 로고 */
+  preroll?: HTMLImageElement;
+  /** 결과 화면 광고 소재 */
+  result?: HTMLImageElement;
   qr?: HTMLImageElement;
 }
 
@@ -85,7 +88,7 @@ function drawPreroll(ctx: CanvasRenderingContext2D, w: number, h: number, ad: Ro
   const labelSize = clamp(h * 0.013, 9, 14);
   const gap = h * 0.022;
 
-  const logo = ready(images.square) ? images.square : undefined;
+  const logo = ready(images.preroll) ? images.preroll : undefined;
 
   const parts = [provideSize, sponsorSize, logo ? logoSize : 0, labelSize];
   const total = parts.reduce((a, b) => a + b, 0) + gap * (parts.filter((p) => p > 0).length - 1);
@@ -124,7 +127,7 @@ function drawResult(
   ad: RoundAd,
   images: AdImages
 ): AdRect | undefined {
-  const logo = ready(images.square) ? images.square : undefined;
+  const logo = ready(images.result) ? images.result : undefined;
   const qr = ready(images.qr) ? images.qr : undefined;
   if (!logo && !qr) return undefined;
 

--- a/src/adService.ts
+++ b/src/adService.ts
@@ -1,4 +1,4 @@
-import type { AdCreative, AdResponse, RoundAd } from './types/Ad.type';
+import type { AdCreative, AdCreativeMap, AdResponse, AdSlotKey, RoundAd } from './types/Ad.type';
 
 const REFRESH_INTERVAL = 60000; // 60 seconds
 
@@ -46,12 +46,19 @@ export class AdService {
       if (!res.ok) return;
       const data = (await res.json()) as AdResponse;
       const ads = Array.isArray(data.ads) ? data.ads : [];
-      this._ads = ads.map((ad) => ({
-        ...ad,
-        wide: (ad.wide ?? []).map((p) => this.resolve(p)),
-        square: (ad.square ?? []).map((p) => this.resolve(p)),
-        qrImage: ad.qrImage ? this.resolve(ad.qrImage) : undefined,
-      }));
+      this._ads = ads.map((ad) => {
+        // 소재를 슬롯별로 나누기 전의 서버는 정사각 한 장을 프리롤과 결과가 함께 썼다
+        const raw = ad.creatives ?? { goal: ad.wide, preroll: ad.square, result: ad.square };
+        const creatives: AdCreativeMap<string[]> = {};
+        for (const [slot, list] of Object.entries(raw)) {
+          if (list?.length) creatives[slot as AdSlotKey] = list.map((p) => this.resolve(p));
+        }
+        return {
+          ...ad,
+          creatives,
+          qrImage: ad.qrImage ? this.resolve(ad.qrImage) : undefined,
+        };
+      });
     } catch {
       this._ads = [];
     }
@@ -73,7 +80,11 @@ export class AdService {
     const creativeCursor = this._creativeCursors.get(ad.id) ?? randomStart();
     this._creativeCursors.set(ad.id, creativeCursor + 1);
 
-    const pick = (list: string[]) => (list.length > 0 ? list[creativeCursor % list.length] : undefined);
+    // 슬롯마다 장수가 달라 같은 커서라도 각자의 주기로 돈다 (프리롤은 1장이라 늘 같다)
+    const creatives: AdCreativeMap<string> = {};
+    for (const [slot, list] of Object.entries(ad.creatives)) {
+      if (list?.length) creatives[slot as AdSlotKey] = list[creativeCursor % list.length];
+    }
 
     this._current = {
       id: ad.id,
@@ -83,8 +94,7 @@ export class AdService {
       qrImage: ad.qrImage,
       linkUrl: ad.linkUrl,
       house: ad.house,
-      wide: pick(ad.wide),
-      square: pick(ad.square),
+      creatives,
     };
     return this._current;
   }

--- a/src/rouletteRenderer.ts
+++ b/src/rouletteRenderer.ts
@@ -156,9 +156,13 @@ export class RouletteRenderer {
   setAd(ad: RoundAd | null): void {
     this._ad = ad;
     if (!ad) return;
-    for (const src of [ad.wide, ad.square, ad.qrImage]) {
+    for (const src of [...Object.values(ad.creatives), ad.qrImage]) {
       if (src) this.cacheAdImage(src);
     }
+  }
+
+  private adImage(src?: string): HTMLImageElement | undefined {
+    return src ? this._adImageCache.get(src) : undefined;
   }
 
   private cacheAdImage(src: string): HTMLImageElement {
@@ -212,8 +216,9 @@ export class RouletteRenderer {
         this._sceneCanvas.height,
         overlay,
         {
-          square: overlay.ad.square ? this._adImageCache.get(overlay.ad.square) : undefined,
-          qr: overlay.ad.qrImage ? this._adImageCache.get(overlay.ad.qrImage) : undefined,
+          preroll: this.adImage(overlay.ad.creatives.preroll),
+          result: this.adImage(overlay.ad.creatives.result),
+          qr: this.adImage(overlay.ad.qrImage),
         },
       );
       this._displayCtx.restore();
@@ -229,8 +234,7 @@ export class RouletteRenderer {
     const ad = this._ad;
     if (!ad || !ad.slots?.includes('goal') || !stage.adBoards?.length) return;
 
-    if (!ad.wide) return;
-    const img = this._adImageCache.get(ad.wide);
+    const img = this.adImage(ad.creatives.goal);
     if (!img?.complete || img.naturalWidth === 0) return;
 
     try {

--- a/src/types/Ad.type.ts
+++ b/src/types/Ad.type.ts
@@ -1,10 +1,13 @@
 export type AdSlotKey = 'preroll' | 'goal' | 'result';
 
+/** 슬롯별 소재. 프리롤에는 로고, 결과 화면에는 광고 소재가 들어가는 식으로 서로 다르다 */
+export type AdCreativeMap<T> = Partial<Record<AdSlotKey, T>>;
+
 export interface AdCreative {
   id: string;
   slots: AdSlotKey[];
-  wide: string[];
-  square: string[];
+  /** 슬롯마다 여러 장일 수 있고, 구동마다 돌아가며 노출된다 */
+  creatives: AdCreativeMap<string[]>;
   advertiser: string;
   tagline?: string;
   qrImage?: string;
@@ -15,8 +18,8 @@ export interface AdCreative {
 export interface RoundAd {
   id: string;
   slots: AdSlotKey[];
-  wide?: string;
-  square?: string;
+  /** 이번 구동에서 슬롯마다 뽑힌 소재 한 장 */
+  creatives: AdCreativeMap<string>;
   advertiser: string;
   tagline?: string;
   qrImage?: string;
@@ -24,6 +27,19 @@ export interface RoundAd {
   house?: boolean;
 }
 
+/**
+ * 서버 응답.
+ *
+ * `wide`/`square` 는 소재를 슬롯별로 나누기 전의 형식이다. 게임이 먼저 배포되고
+ * 서버가 뒤따르는 동안 옛 서버를 만날 수 있어 폴백으로만 읽는다.
+ * 서버에서 두 필드가 사라지면 여기서도 지운다.
+ */
 export interface AdResponse {
-  ads: AdCreative[];
+  ads: (Omit<AdCreative, 'creatives'> & {
+    creatives?: AdCreativeMap<string[]>;
+    /** @deprecated */
+    wide?: string[];
+    /** @deprecated */
+    square?: string[];
+  })[];
 }


### PR DESCRIPTION
프리롤에는 로고, 결과 화면에는 광고 소재처럼 서로 다른 이미지를 쓰는
경우가 대부분인데 정사각 한 장을 두 슬롯이 공유하고 있었다.
소재 종류를 슬롯 키와 1:1 로 맞춘다 (wide/square → preroll/goal/result).

서버가 아직 옛 형식을 내려주는 동안에도 지금과 같은 화면이 나오도록
wide/square 폴백을 둔다. 서버에서 두 필드가 사라지면 폴백도 함께 지운다.