### PR TITLE
feat) 결과 광고에 일정 시간 후 닫기 버튼 추가

### DIFF
--- a/src/adRenderer.ts
+++ b/src/adRenderer.ts
@@ -16,6 +16,8 @@ export interface AdOverlayState {
   since: number;
   endingSince?: number;
   clickRect?: AdRect;
+  /** 노출 후 일정 시간이 지나야 생긴다. 없으면 아직 닫을 수 없다 */
+  closeRect?: AdRect;
 }
 
 export interface AdImages {
@@ -37,6 +39,12 @@ const QR_TO_LOGO_RATIO = 0.5;
 
 const FADE_IN_MS = 250;
 const FADE_OUT_MS = 200;
+
+/** 결과 광고를 이만큼 보여준 뒤에 닫기 버튼을 내준다 */
+const CLOSE_DELAY_MS = 5000;
+const CLOSE_FADE_MS = 250;
+const CLOSE_INSET = 12;
+const CLOSE_HIT_PADDING = 8;
 
 const SERIF = `'Nanum Myeongjo', 'Noto Serif KR', AppleMyungjo, Batang, serif`;
 const SANS = `-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif`;
@@ -71,7 +79,9 @@ export function drawAdOverlay(
   if (state.mode === 'preroll') {
     drawPreroll(ctx, w, h, state.ad, images);
   } else {
-    state.clickRect = drawResult(ctx, w, h, state.ad, images);
+    const rects = drawResult(ctx, w, h, state.ad, images, now - state.since);
+    state.clickRect = rects?.click;
+    state.closeRect = rects?.close;
   }
 
   ctx.restore();
@@ -125,8 +135,9 @@ function drawResult(
   w: number,
   h: number,
   ad: RoundAd,
-  images: AdImages
-): AdRect | undefined {
+  images: AdImages,
+  elapsed: number
+): { click?: AdRect; close?: AdRect } | undefined {
   const logo = ready(images.result) ? images.result : undefined;
   const qr = ready(images.qr) ? images.qr : undefined;
   if (!logo && !qr) return undefined;
@@ -188,7 +199,47 @@ function drawResult(
   ctx.textBaseline = 'bottom';
   ctx.fillText('광고', RESULT_LABEL_INSET, bandY + bandH - RESULT_LABEL_INSET);
 
-  return clickRect;
+  return { click: clickRect, close: drawCloseButton(ctx, w, bandY, h, elapsed) };
+}
+
+/** 밴드 오른쪽 위 구석의 닫기 버튼. 아직 나올 때가 아니면 그리지도, 누를 수도 없다 */
+function drawCloseButton(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  bandY: number,
+  h: number,
+  elapsed: number
+): AdRect | undefined {
+  if (elapsed < CLOSE_DELAY_MS) return undefined;
+
+  const size = clamp(h * 0.045, 20, 34);
+  const cx = w - CLOSE_INSET - size / 2;
+  const cy = bandY + CLOSE_INSET + size / 2;
+  const arm = size * 0.22;
+
+  ctx.save();
+  ctx.globalAlpha *= Math.min(1, (elapsed - CLOSE_DELAY_MS) / CLOSE_FADE_MS);
+  ctx.beginPath();
+  ctx.arc(cx, cy, size / 2, 0, Math.PI * 2);
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
+  ctx.lineWidth = Math.max(1.5, size * 0.07);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(cx - arm, cy - arm);
+  ctx.lineTo(cx + arm, cy + arm);
+  ctx.moveTo(cx + arm, cy - arm);
+  ctx.lineTo(cx - arm, cy + arm);
+  ctx.stroke();
+  ctx.restore();
+
+  return {
+    x: cx - size / 2 - CLOSE_HIT_PADDING,
+    y: cy - size / 2 - CLOSE_HIT_PADDING,
+    w: size + CLOSE_HIT_PADDING * 2,
+    h: size + CLOSE_HIT_PADDING * 2,
+  };
 }
 
 function clamp(v: number, min: number, max: number): number {

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -10,7 +10,7 @@ import options from './options';
 import { ParticleManager } from './particleManager';
 import { Box2dPhysics } from './physics-box2d';
 import { RankRenderer } from './rankRenderer';
-import { RouletteRenderer } from './rouletteRenderer';
+import { type AdHit, RouletteRenderer } from './rouletteRenderer';
 import { SkillEffect } from './skillEffect';
 import type { RoundAd } from './types/Ad.type';
 import type { ColorTheme } from './types/ColorTheme';
@@ -295,12 +295,17 @@ export class Roulette extends EventTarget {
     });
 
     canvas.addEventListener('click', (e) => {
-      const link = this.adLinkAt(e);
-      if (link) window.open(link, '_blank', 'noopener');
+      const hit = this.adHitAt(e);
+      if (!hit) return;
+      if (hit.type === 'close') {
+        this.hideAdOverlay();
+      } else {
+        window.open(hit.url, '_blank', 'noopener');
+      }
     });
 
     canvas.addEventListener('pointermove', (e) => {
-      canvas.style.cursor = this.adLinkAt(e) ? 'pointer' : '';
+      canvas.style.cursor = this.adHitAt(e) ? 'pointer' : '';
     });
   }
 
@@ -367,9 +372,9 @@ export class Roulette extends EventTarget {
     this._renderer.hideAdOverlay();
   }
 
-  private adLinkAt(e: MouseEvent): string | null {
+  private adHitAt(e: MouseEvent): AdHit | null {
     const sizeFactor = this._renderer.sizeFactor;
-    return this._renderer.getAdLinkAt(e.offsetX * sizeFactor, e.offsetY * sizeFactor);
+    return this._renderer.getAdHitAt(e.offsetX * sizeFactor, e.offsetY * sizeFactor);
   }
 
   public setTheme(themeName: keyof typeof Themes) {

--- a/src/rouletteRenderer.ts
+++ b/src/rouletteRenderer.ts
@@ -1,4 +1,4 @@
-import { type AdOverlayMode, type AdOverlayState, drawAdOverlay } from './adRenderer';
+import { type AdOverlayMode, type AdOverlayState, type AdRect, drawAdOverlay } from './adRenderer';
 import type { Camera } from './camera';
 import { canvasHeight, canvasWidth, initialZoom, Themes, winnerAreaHeight } from './data/constants';
 import type { StageDef } from './data/maps';
@@ -28,6 +28,12 @@ export type RenderParameters = {
 
 const MAX_DISPLAY_WIDTH = 1920;
 const WINNER_TEXT_OFFSET = 30;
+
+export type AdHit = { type: 'close' } | { type: 'link'; url: string };
+
+function inRect(rect: AdRect | undefined, x: number, y: number): boolean {
+  return !!rect && x >= rect.x && x <= rect.x + rect.w && y >= rect.y && y <= rect.y + rect.h;
+}
 
 export class RouletteRenderer {
   protected _canvas!: HTMLCanvasElement;
@@ -180,16 +186,16 @@ export class RouletteRenderer {
     this._adOverlay = { mode, ad: this._ad, since: performance.now(), endingSince: undefined };
   }
 
-  getAdLinkAt(x: number, y: number): string | null {
+  getAdHitAt(x: number, y: number): AdHit | null {
     const overlay = this._adOverlay;
     if (!overlay || overlay.endingSince !== undefined) return null;
 
-    const rect = overlay.clickRect;
-    const link = overlay.ad.linkUrl;
-    if (!rect || !link) return null;
+    if (inRect(overlay.closeRect, x, y)) return { type: 'close' };
 
-    const inside = x >= rect.x && x <= rect.x + rect.w && y >= rect.y && y <= rect.y + rect.h;
-    return inside ? link : null;
+    const link = overlay.ad.linkUrl;
+    if (link && inRect(overlay.clickRect, x, y)) return { type: 'link', url: link };
+
+    return null;
   }
 
   hideAdOverlay(): void {
@@ -210,17 +216,11 @@ export class RouletteRenderer {
     try {
       this._displayCtx.save();
       this._displayCtx.scale(scale, scale);
-      const alive = drawAdOverlay(
-        this._displayCtx,
-        this._sceneCanvas.width,
-        this._sceneCanvas.height,
-        overlay,
-        {
-          preroll: this.adImage(overlay.ad.creatives.preroll),
-          result: this.adImage(overlay.ad.creatives.result),
-          qr: this.adImage(overlay.ad.qrImage),
-        },
-      );
+      const alive = drawAdOverlay(this._displayCtx, this._sceneCanvas.width, this._sceneCanvas.height, overlay, {
+        preroll: this.adImage(overlay.ad.creatives.preroll),
+        result: this.adImage(overlay.ad.creatives.result),
+        qr: this.adImage(overlay.ad.qrImage),
+      });
       this._displayCtx.restore();
       if (!alive) this._adOverlay = null;
     } catch (e) {
@@ -276,7 +276,7 @@ export class RouletteRenderer {
     this.onAfterScene();
 
     uiObjects.forEach((obj) =>
-      obj.render(this.ctx, renderParameters, this._sceneCanvas.width, this._sceneCanvas.height),
+      obj.render(this.ctx, renderParameters, this._sceneCanvas.width, this._sceneCanvas.height)
     );
     renderParameters.particleManager.render(this.ctx);
     this.renderWinner(renderParameters);


### PR DESCRIPTION
@
## 배경

결과 광고는 당첨 후 리셋 전까지 계속 떠 있어서 화면을 가린다는 의견이 있었습니다.
노출은 지키되, 일정 시간이 지나면 사용자가 직접 치울 수 있게 했습니다.

## 변경

- `adRenderer.ts` — 결과 밴드 오른쪽 위 구석에 닫기(✕) 버튼. 노출 후 `CLOSE_DELAY_MS`(5초)가 지나야 그려지고 250ms 페이드인. 그 전에는 `closeRect` 자체를 만들지 않아 눌릴 수 없음
- `rouletteRenderer.ts` — `getAdLinkAt` → `getAdHitAt`. 닫기를 먼저 판정하고 나머지는 기존처럼 링크로 처리
- `roulette.ts` — 클릭이 `close`면 기존 `hideAdOverlay()`(200ms 페이드아웃) 재사용, `link`면 기존대로 새 탭

노출 시간과 지연값은 `CLOSE_DELAY_MS` 한 곳에서 조절합니다.

## 검증

headless Chrome 으로 가짜 광고를 주입하고 실제 라운드를 돌려 확인했습니다.

| 시점 | 결과 |
|---|---|
| t+1.5s | `closeRect` 없음 / `clickRect` 있음 (아직 못 닫음, 링크는 동작) |
| t+6s | `closeRect` 생성, 커서 `pointer` |
| 클릭 | 오버레이 제거, 링크 팝업 안 열림 |

## 남긴 것

- 닫기 클릭 트래킹은 넣지 않았습니다 (서버에 해당 엔드포인트 없음). 필요해지면 추가합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@