### PR TITLE
feat) 결과 광고를 노출 후 좌상단으로 이동·축소

### DIFF
--- a/src/adRenderer.ts
+++ b/src/adRenderer.ts
@@ -40,6 +40,10 @@ const QR_TO_LOGO_RATIO = 0.5;
 const FADE_IN_MS = 250;
 const FADE_OUT_MS = 200;
 
+/** 결과 광고는 한가운데서 시작해 이만큼 뒤에 위로 비켜준다 */
+const RESULT_MOVE_DELAY_MS = 2500;
+const RESULT_MOVE_MS = 600;
+
 /** 결과 광고를 이만큼 보여준 뒤에 닫기 버튼을 내준다 */
 const CLOSE_DELAY_MS = 5000;
 const CLOSE_FADE_MS = 250;
@@ -145,7 +149,7 @@ function drawResult(
   const logoSize = winnerAreaHeight;
   const qrSize = winnerAreaHeight * QR_TO_LOGO_RATIO;
   const bandH = logoSize + RESULT_BAND_PADDING * 2;
-  const bandY = (h - bandH) / 2;
+  const bandY = resultBandY(h, bandH, elapsed);
   const contentY = bandY + RESULT_BAND_PADDING;
 
   ctx.fillStyle = RESULT_BAND_COLOR;
@@ -200,6 +204,20 @@ function drawResult(
   ctx.fillText('광고', RESULT_LABEL_INSET, bandY + bandH - RESULT_LABEL_INSET);
 
   return { click: clickRect, close: drawCloseButton(ctx, w, bandY, h, elapsed) };
+}
+
+/**
+ * 처음엔 화면 한가운데에 세워 눈에 띄게 하고, 잠깐 뒤 화면 위로 미끄러져 비켜준다.
+ * 밴드 안의 로고·텍스트·QR·닫기 버튼이 모두 이 값에서 파생되므로 여기만 움직이면 된다.
+ */
+function resultBandY(h: number, bandH: number, elapsed: number): number {
+  const center = (h - bandH) / 2;
+  const t = clamp((elapsed - RESULT_MOVE_DELAY_MS) / RESULT_MOVE_MS, 0, 1);
+  return center * (1 - easeInOut(t));
+}
+
+function easeInOut(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
 }
 
 /** 밴드 오른쪽 위 구석의 닫기 버튼. 아직 나올 때가 아니면 그리지도, 누를 수도 없다 */

--- a/src/adRenderer.ts
+++ b/src/adRenderer.ts
@@ -35,12 +35,14 @@ const RESULT_TAGLINE_GAP_EM = 0.8;
 const RESULT_BAND_PADDING = 12;
 const RESULT_BAND_COLOR = 'rgba(0, 0, 0, 0.75)';
 const RESULT_LABEL_INSET = 12;
+/** 좌상단으로 붙었을 때 '광고' 라벨이 로고와 겹치지 않게 비워두는 왼쪽 여백 */
+const RESULT_LABEL_GUTTER = 34;
 const QR_TO_LOGO_RATIO = 0.5;
 
 const FADE_IN_MS = 250;
 const FADE_OUT_MS = 200;
 
-/** 결과 광고는 한가운데서 시작해 이만큼 뒤에 위로 비켜준다 */
+/** 결과 광고는 한가운데 전체 폭으로 시작해, 이만큼 뒤에 좌상단으로 오므라든다 */
 const RESULT_MOVE_DELAY_MS = 2500;
 const RESULT_MOVE_MS = 600;
 
@@ -148,44 +150,54 @@ function drawResult(
 
   const logoSize = winnerAreaHeight;
   const qrSize = winnerAreaHeight * QR_TO_LOGO_RATIO;
+  const nameSize = logoSize * RESULT_NAME_RATIO;
+  const taglineSize = logoSize * RESULT_TAGLINE_RATIO;
   const bandH = logoSize + RESULT_BAND_PADDING * 2;
-  const bandY = resultBandY(h, bandH, elapsed);
+
+  // 오므라든 폭을 알아야 밴드를 먼저 깔 수 있어서, 글자 폭은 그리기 전에 재둔다
+  ctx.font = `600 ${nameSize}px ${SANS}`;
+  const nameMetrics = ctx.measureText(ad.advertiser);
+  let colWidth = nameMetrics.width;
+  if (ad.tagline) {
+    ctx.font = `${taglineSize}px ${SANS}`;
+    colWidth = Math.max(colWidth, ctx.measureText(ad.tagline).width);
+  }
+  if (qr) colWidth = Math.max(colWidth, qrSize);
+
+  const t = easeInOut(clamp((elapsed - RESULT_MOVE_DELAY_MS) / RESULT_MOVE_MS, 0, 1));
+  // 오므라들면 오른쪽 위 구석이 광고주명 자리가 되므로, 닫기 버튼 자리를 따로 비워둔다
+  const dockedW =
+    RESULT_LABEL_GUTTER + logoSize + RESULT_GAP + colWidth + RESULT_BAND_PADDING * 2 + closeButtonSize(h) + CLOSE_INSET;
+
+  const bandY = lerp((h - bandH) / 2, 0, t);
+  const bandW = lerp(w, Math.min(dockedW, w), t);
   const contentY = bandY + RESULT_BAND_PADDING;
+  const logoX = lerp((w - logoSize) / 2, RESULT_BAND_PADDING + RESULT_LABEL_GUTTER, t);
+  const colX = logoX + logoSize + RESULT_GAP;
 
   ctx.fillStyle = RESULT_BAND_COLOR;
-  ctx.fillRect(0, bandY, w, bandH);
-
-  const logoX = (w - logoSize) / 2;
+  ctx.fillRect(0, bandY, bandW, bandH);
 
   if (logo) {
     ctx.drawImage(logo, logoX, contentY, logoSize, logoSize);
   }
 
-  const colX = logoX + logoSize + RESULT_GAP;
-  const nameSize = logoSize * RESULT_NAME_RATIO;
-
   ctx.font = `600 ${nameSize}px ${SANS}`;
   ctx.fillStyle = '#ffffff';
   ctx.textAlign = 'left';
   ctx.textBaseline = 'alphabetic';
-  const nameMetrics = ctx.measureText(ad.advertiser);
   const ascent = nameMetrics.actualBoundingBoxAscent || nameSize * 0.8;
   ctx.fillText(ad.advertiser, colX, contentY + ascent);
-  let colWidth = nameMetrics.width;
 
-  const qrTop = qr ? contentY + logoSize - qrSize : contentY + logoSize;
   if (ad.tagline) {
-    const taglineSize = logoSize * RESULT_TAGLINE_RATIO;
     ctx.font = `${taglineSize}px ${SANS}`;
     ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
     ctx.textBaseline = 'top';
-    colWidth = Math.max(colWidth, ctx.measureText(ad.tagline).width);
     ctx.fillText(ad.tagline, colX, contentY + nameSize + taglineSize * RESULT_TAGLINE_GAP_EM);
   }
 
   if (qr) {
-    ctx.drawImage(qr, colX, qrTop, qrSize, qrSize);
-    colWidth = Math.max(colWidth, qrSize);
+    ctx.drawImage(qr, colX, contentY + logoSize - qrSize, qrSize, qrSize);
   }
 
   const clickLeft = logo ? logoX : colX;
@@ -203,17 +215,15 @@ function drawResult(
   ctx.textBaseline = 'bottom';
   ctx.fillText('광고', RESULT_LABEL_INSET, bandY + bandH - RESULT_LABEL_INSET);
 
-  return { click: clickRect, close: drawCloseButton(ctx, w, bandY, h, elapsed) };
+  return { click: clickRect, close: drawCloseButton(ctx, bandW, bandY, h, elapsed) };
 }
 
-/**
- * 처음엔 화면 한가운데에 세워 눈에 띄게 하고, 잠깐 뒤 화면 위로 미끄러져 비켜준다.
- * 밴드 안의 로고·텍스트·QR·닫기 버튼이 모두 이 값에서 파생되므로 여기만 움직이면 된다.
- */
-function resultBandY(h: number, bandH: number, elapsed: number): number {
-  const center = (h - bandH) / 2;
-  const t = clamp((elapsed - RESULT_MOVE_DELAY_MS) / RESULT_MOVE_MS, 0, 1);
-  return center * (1 - easeInOut(t));
+function closeButtonSize(h: number): number {
+  return clamp(h * 0.045, 20, 34);
+}
+
+function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
 }
 
 function easeInOut(t: number): number {
@@ -230,7 +240,7 @@ function drawCloseButton(
 ): AdRect | undefined {
   if (elapsed < CLOSE_DELAY_MS) return undefined;
 
-  const size = clamp(h * 0.045, 20, 34);
+  const size = closeButtonSize(h);
   const cx = w - CLOSE_INSET - size / 2;
   const cy = bandY + CLOSE_INSET + size / 2;
   const arm = size * 0.22;


### PR DESCRIPTION
@
## 배경

결과 광고가 화면 정중앙을 전체 폭으로 가로막아 당첨 화면을 보기 불편하다는 의견이 있었습니다.
첫 노출의 임팩트는 그대로 두고, 잠깐 뒤에 비켜주는 쪽으로 잡았습니다.

## 동작

한가운데 전체 폭으로 등장 → 2.5초 유지 → 600ms 동안 좌상단으로 **이동 + 축소** → 5초에 닫기 버튼

보간하는 값은 셋뿐입니다. 나머지(로고·광고주명·태그라인·QR·닫기 버튼·클릭 영역)는 전부 여기서 파생됩니다.

| 값 | 시작 | 끝 |
|---|---|---|
| `bandY` | 세로 중앙 | 0 |
| `bandW` | 화면 전체 폭 | 콘텐츠 폭 |
| `logoX` | 가로 중앙 | 왼쪽 |

## 레이아웃에서 걸린 것

- **밴드 폭을 먼저 알아야** 배경을 깔 수 있어서, 그리면서 재던 글자 폭 측정을 그리기 전으로 옮겼습니다.
- 오므라들면 **오른쪽 위 구석이 곧 광고주명 자리**라 닫기 버튼과 겹칩니다. `dockedW`에 버튼 몫을 미리 넣었습니다.
- 같은 이유로 **`광고` 라벨이 로고와 겹쳐서** 왼쪽에 `RESULT_LABEL_GUTTER`(34px) 여백을 뒀습니다. 고지 요소라 가려지면 안 되는 부분입니다.
- 폭이 줄면서 우상단 순위 목록과의 겹침은 자연히 사라졌습니다.

## 검증

headless Chrome 으로 가짜 광고를 주입하고 실제 라운드를 돌려 확인했습니다 (scene 800x450 기준).

| 시점 | 결과 |
|---|---|
| t+1.2s | `bandY` 129 / `logoX` 316 — 기존과 동일한 중앙 배치 |
| t+3.4s | `bandY` 0 / `logoX` 46 — 좌상단 도킹 |
| t+5.6s | 닫기 버튼 `x` 361 (텍스트 끝 356 뒤), 커서 `pointer` |
| 클릭 | 오버레이 제거, 링크 팝업 안 열림 |

## 손잡이

`RESULT_MOVE_DELAY_MS`(2500) / `RESULT_MOVE_MS`(600) 두 값으로 조절합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@