### PR TITLE
feat) 광고 소재를 목록 수신 직후에 미리 받아두기

### DIFF
--- a/src/adService.ts
+++ b/src/adService.ts
@@ -12,6 +12,9 @@ export class AdService {
   private _apiBase: string;
   private _intervalId: number | null = null;
 
+  /** 목록이 새로 들어올 때마다 불린다. 소재를 미리 받아두는 데 쓴다 */
+  onUpdate?: () => void;
+
   constructor(apiBase: string) {
     this._apiBase = apiBase.replace(/\/$/, '');
   }
@@ -62,10 +65,26 @@ export class AdService {
     } catch {
       this._ads = [];
     }
+    this.onUpdate?.();
   }
 
   private resolve(path: string): string {
     return path.startsWith('/') ? `${this._apiBase}${path}` : path;
+  }
+
+  /**
+   * 다음 `pickForRound()`가 고를 광고의 소재 URL 전부. 커서는 건드리지 않는다.
+   * 어느 장이 뽑힐지는 슬롯별 커서에 달려 있어, 그 광고 것은 다 받아둔다.
+   */
+  nextUrls(): string[] {
+    if (this._ads.length === 0) return [];
+    const ad = this._ads[this._cursor % this._ads.length];
+    const urls: string[] = [];
+    for (const list of Object.values(ad.creatives)) {
+      if (list) urls.push(...list);
+    }
+    if (ad.qrImage) urls.push(ad.qrImage);
+    return urls;
   }
 
   pickForRound(): RoundAd | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ const roulette = new Roulette();
 const isLocalhost = ['localhost', '127.0.0.1'].includes(location.hostname);
 const adService = new AdService(isLocalhost ? 'http://localhost:3000' : 'https://marblerouletteshop.com');
 
+// 소재를 시작 버튼 누른 뒤에 받으면 프리롤이 로고 없이 떴다가 늦게 채워진다. 미리 받아둔다
+const preloadNextAd = () => roulette.preloadAdImages(adService.nextUrls());
+adService.onUpdate = preloadNextAd;
 adService.init();
 
 (window as any).roulette = roulette;
@@ -35,6 +38,7 @@ function once(fn: () => void): () => void {
       ad = adService.pickForRound();
       roulette.setAd(ad);
       if (ad) adService.trackImpression();
+      preloadNextAd();
     } catch (e) {
       console.error('[ads] 광고 준비 실패, 광고 없이 진행합니다', e);
       ad = null;

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -364,6 +364,10 @@ export class Roulette extends EventTarget {
     this._renderer.setAd(ad);
   }
 
+  public preloadAdImages(srcs: (string | undefined)[]) {
+    this._renderer.preloadAdImages(srcs);
+  }
+
   public showAdOverlay(mode: 'preroll' | 'result') {
     this._renderer.showAdOverlay(mode);
   }

--- a/src/rouletteRenderer.ts
+++ b/src/rouletteRenderer.ts
@@ -162,7 +162,12 @@ export class RouletteRenderer {
   setAd(ad: RoundAd | null): void {
     this._ad = ad;
     if (!ad) return;
-    for (const src of [...Object.values(ad.creatives), ad.qrImage]) {
+    this.preloadAdImages([...Object.values(ad.creatives), ad.qrImage]);
+  }
+
+  /** 소재를 미리 받아둔다. 여기서 만든 엘리먼트를 나중에 그대로 그리므로 캐시 헤더와 무관하게 즉시 뜬다 */
+  preloadAdImages(srcs: (string | undefined)[]): void {
+    for (const src of srcs) {
       if (src) this.cacheAdImage(src);
     }
   }


### PR DESCRIPTION
## 문제

시작 버튼을 누른 뒤에야 광고 소재 다운로드가 시작돼서, 1500ms짜리 프리롤이 로고 없이 떴다가 뒤늦게 채워지는 경우가 많았다.

- `adService.init()`(페이지 로드 시)은 **메타데이터 JSON만** 가져온다. 소재 URL을 알게 될 뿐 다운로드는 하지 않는다.
- 실제 `new Image()` 요청은 시작 버튼 → `pickForRound()` → `setAd()` → `cacheAdImage()` 시점에 최초로 나간다.
- 그 안에 못 받으면 `ready()`가 false라 로고 자리를 통째로 빼고 그리고, 소재가 늦게 도착하면 레이아웃이 튄다.

즉 다운로드 **시점**이 문제였고, 캐시 구조는 이미 있었다.

## 변경

다운로드 시점을 "시작 버튼"에서 "광고 목록 수신 직후"로 앞당긴다. 렌더러의 기존 `_adImageCache`를 그대로 재사용해서, 프리로드한 `HTMLImageElement`가 나중에 렌더에 쓰이는 **바로 그 객체**가 되게 했다 (HTTP 캐시 헤더에 의존하지 않는다).

- `rouletteRenderer.ts` — public `preloadAdImages(srcs)` 추가. `setAd()`도 이걸 호출
- `roulette.ts` — 패스스루
- `adService.ts` — `nextUrls()`: 다음 `pickForRound()`가 고를 광고의 소재 URL을 **커서를 올리지 않고** 반환. 어느 장이 뽑힐지는 슬롯별 커서에 달려 있어 그 광고 것은 다 받아둔다
- `adService.ts` — `onUpdate?: () => void` 훅을 `fetchAds()` 끝에서 호출 (최초 로드 + 60초 주기 갱신 둘 다 커버)
- `index.ts` — `onUpdate`에 프리로드 연결 + `pickForRound()` 직후 한 번 더 호출해 다음 판 소재를 미리 데운다

## 검증

소재를 1500ms 지연해서 주는 목 광고 서버를 띄우고, headless Chrome으로 `페이지 로드 → 4초 대기 → 시작 버튼 클릭 → 400ms 후 캡처`. 같은 스크립트를 `main`에서도 돌려 대조했다.

| | main | 이 PR |
|---|---|---|
| 시작 버튼 **전** 소재 요청 | 0건 | **4건 (+397ms, 페이지 로드 직후)** |
| 시작 버튼 **후** 소재 요청 | 4건 | **0건** |
| 시작 전 렌더러 캐시 | 비어 있음 | 4장 전부 READY |
| 클릭 +400ms 프리롤 로고 영역 | 29.3% (로고 없음) | **90.0% (로고 있음)** |

`yarn lint`, `yarn build` 통과.
`npx tsc --noEmit`에 `roulette.ts:186` 에러가 1건 남지만 main에도 있는 기존 문제로, 이번 변경과 무관하다.

## 하지 않은 것

- 모든 광고의 모든 소재 프리로드 → 광고 수가 늘면 낭비라 다음 1건만
- `<link rel="preload">` 주입 → 이미 Image 캐시가 있어 불필요
- 소재가 그래도 늦을 때 프리롤 타이머를 `img.decode()`까지 지연 → 프리로드로 해결이 안 될 때 추가
