### PR TITLE
공이 끝에서 보였다 안보였다 하는 문제 해결

### DIFF
--- a/src/marble.ts
+++ b/src/marble.ts
@@ -118,10 +118,11 @@ export class Marble {
     this.theme = theme;
     const viewPortHw = viewPort.w / viewPort.zoom / 2;
     const viewPortHh = viewPort.h / viewPort.zoom / 2;
-    const viewPortLeft = viewPort.x - viewPortHw;
-    const viewPortRight = viewPort.x + viewPortHw;
-    const viewPortTop = viewPort.y - viewPortHh - this.size / 2;
-    const viewPortBottom = viewPort.y + viewPortHh;
+    const cullMargin = this.size / 2;
+    const viewPortLeft = viewPort.x - viewPortHw - cullMargin;
+    const viewPortRight = viewPort.x + viewPortHw + cullMargin;
+    const viewPortTop = viewPort.y - viewPortHh - cullMargin;
+    const viewPortBottom = viewPort.y + viewPortHh + cullMargin;
     if (
       !isMinimap &&
       (this.x < viewPortLeft || this.x > viewPortRight || this.y < viewPortTop || this.y > viewPortBottom)

--- a/src/marble.ts
+++ b/src/marble.ts
@@ -124,10 +124,10 @@ export class Marble {
     const viewPortBottom = viewPort.y + viewPortHh;
     const halfSize = this.size / 2;
     const isOutsideView = (
-      this.x - halfSize < viewPortLeft || 
-      this.x + halfSize > viewPortRight || 
-      this.y - halfSize < viewPortTop || 
-      this.y + halfSize > viewPortBottom
+      this.x + halfSize < viewPortLeft ||
+      this.x - halfSize > viewPortRight ||
+      this.y + halfSize < viewPortTop ||
+      this.y - halfSize > viewPortBottom
     );
     if (!isMinimap && isOutsideView) {
       return;

--- a/src/marble.ts
+++ b/src/marble.ts
@@ -118,15 +118,18 @@ export class Marble {
     this.theme = theme;
     const viewPortHw = viewPort.w / viewPort.zoom / 2;
     const viewPortHh = viewPort.h / viewPort.zoom / 2;
-    const cullMargin = this.size / 2;
-    const viewPortLeft = viewPort.x - viewPortHw - cullMargin;
-    const viewPortRight = viewPort.x + viewPortHw + cullMargin;
-    const viewPortTop = viewPort.y - viewPortHh - cullMargin;
-    const viewPortBottom = viewPort.y + viewPortHh + cullMargin;
-    if (
-      !isMinimap &&
-      (this.x < viewPortLeft || this.x > viewPortRight || this.y < viewPortTop || this.y > viewPortBottom)
-    ) {
+    const viewPortLeft = viewPort.x - viewPortHw;
+    const viewPortRight = viewPort.x + viewPortHw;
+    const viewPortTop = viewPort.y - viewPortHh;
+    const viewPortBottom = viewPort.y + viewPortHh;
+    const halfSize = this.size / 2;
+    const isOutsideView = (
+      this.x - halfSize < viewPortLeft || 
+      this.x + halfSize > viewPortRight || 
+      this.y - halfSize < viewPortTop || 
+      this.y + halfSize > viewPortBottom
+    );
+    if (!isMinimap && isOutsideView) {
       return;
     }
     const transform = ctx.getTransform();


### PR DESCRIPTION
공이 끝에서 보였다 안보였다 하는 문제 해결
원래는 끝에서 공의 중심으로 랜더 할지 말지를 정해서 공의 중심이 나가자마자 아직 일부분이 카메라에 있지만 랜더 안되는 현상을 해결 #69 pull은 실수였어요 ㅠㅠ