### PR TITLE
fix) 빨리감기 오발동·슬로모션 중 stuck 오판 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "lint": "biome check --fix src/",
     "dev": "parcel index.html --port 1235",
-    "build": "parcel build index.html --public-url /roulette/ && node scripts/build-sw.js"
+    "build": "parcel build index.html --public-url /roulette/ && node scripts/build-sw.js",
+    "simulate": "npx -y tsx scripts/simulate.ts"
   },
   "dependencies": {
     "box2d-wasm": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "@parcel/transformer-sass": "^2.16.4",
     "@parcel/transformer-webmanifest": "^2.16.4",
     "parcel": "^2.16.4",
+    "tsx": "^4.23.13",
     "typescript": "^5.6.3"
   },
   "scripts": {
     "lint": "biome check --fix src/",
     "dev": "parcel index.html --port 1235",
     "build": "parcel build index.html --public-url /roulette/ && node scripts/build-sw.js",
-    "simulate": "npx -y tsx scripts/simulate.ts"
+    "simulate": "tsx scripts/simulate.ts"
   },
   "dependencies": {
     "box2d-wasm": "^7.0.0"

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -1,8 +1,8 @@
 /**
  * 렌더링 없이 물리만 돌려보는 시뮬레이션. 게임 루프와 같은 10ms 고정 스텝, Marble 과 같은 배치·정지 판정·shake 를 쓴다.
  *
- *   npx tsx scripts/simulate.ts bench [6,16,30,100,300,1000]   맵별·구슬 수별 골인 시각 분포 (timeScale 1)
- *   npx tsx scripts/simulate.ts stuck [6,16,30]                 정지 판정 문턱 기존 vs 수정, timeScale 1 과 0.2 에서 shake 비교
+ *   yarn simulate bench [6,16,30,100,300,1000]   맵별·구슬 수별 골인 시각 분포 (timeScale 1)
+ *   yarn simulate stuck [6,16,30]                정지 판정 문턱 기존 vs 수정, timeScale 1 과 0.2 에서 shake 비교
  *
  * Math.random 을 시드 고정으로 바꿔서 같은 조건이면 같은 궤적이 나온다.
  */

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -1,0 +1,168 @@
+/**
+ * 렌더링 없이 물리만 돌려보는 시뮬레이션. 게임 루프와 같은 10ms 고정 스텝, Marble 과 같은 배치·정지 판정·shake 를 쓴다.
+ *
+ *   npx tsx scripts/simulate.ts bench [6,16,30,100,300,1000]   맵별·구슬 수별 골인 시각 분포 (timeScale 1)
+ *   npx tsx scripts/simulate.ts stuck [6,16,30]                 정지 판정 문턱 기존 vs 수정, timeScale 1 과 0.2 에서 shake 비교
+ *
+ * Math.random 을 시드 고정으로 바꿔서 같은 조건이면 같은 궤적이 나온다.
+ */
+import * as fs from 'node:fs';
+import Box2DFactory from 'box2d-wasm';
+import { STUCK_DELAY } from '../src/data/constants';
+import { stages } from '../src/data/maps';
+import { Box2dPhysics } from '../src/physics-box2d';
+
+const STEP_MS = 10;
+const MAX_SIM_SEC = 900;
+/** Marble.update 의 정지 판정 문턱. 10ms 에 √1e-5 ≈ 0.00316 이동, 속도로는 약 0.32/s */
+const STUCK_LEN_SQ = 0.00001;
+const STUCK_SPEED = Math.sqrt(STUCK_LEN_SQ) / (STEP_MS / 1000);
+
+function seedRandom(seed: number) {
+  let a = seed >>> 0;
+  Math.random = () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Node 의 emscripten 로더가 fetch 로 wasm 경로를 열려다 실패하므로 바이너리를 직접 넘긴다
+class NodePhysics extends Box2dPhysics {
+  async init(): Promise<void> {
+    const wasmBinary = fs.readFileSync(new URL('../node_modules/box2d-wasm/dist/umd/Box2D.simd.wasm', import.meta.url));
+    const self = this as any;
+    self.Box2D = await Box2DFactory({ wasmBinary } as any);
+    self.gravity = new self.Box2D.b2Vec2(0, 10);
+    self.world = new self.Box2D.b2World(self.gravity);
+  }
+}
+
+type Options = {
+  mapIdx: number;
+  n: number;
+  timeScale: number;
+  /** 정지 판정에 쓸 lenSq 문턱. 기존 코드는 timeScale 과 무관하게 STUCK_LEN_SQ 고정 */
+  stuckLenSq: number;
+  seed: number;
+};
+
+type Result = {
+  title: string;
+  goals: number[];
+  unfinished: number;
+  outOfBounds: number;
+  shakes: number;
+  /** shake 가 발동한 순간 구슬이 STUCK_SPEED 이상으로 움직이고 있던 횟수 = 멈춘 게 아닌데 튕긴 것 */
+  shakesWhileMoving: number;
+};
+
+async function simulate({ mapIdx, n, timeScale, stuckLenSq, seed }: Options): Promise<Result> {
+  seedRandom(seed);
+  const stage = stages[mapIdx];
+  const p = new NodePhysics();
+  await p.init();
+  p.createStage(stage);
+
+  // Marble 생성자와 같은 배치
+  const maxLine = Math.ceil(n / 10);
+  const lineDelta = -Math.max(0, Math.ceil(maxLine - 5));
+  for (let order = 0; order < n; order++) {
+    const line = Math.floor(order / 10);
+    p.createMarble(order, 10.25 + (order % 10) * 0.6, maxLine - line + lineDelta);
+  }
+  p.start();
+
+  const alive = new Set<number>([...Array(n).keys()]);
+  const last = new Map<number, { x: number; y: number }>();
+  const stuckMs = new Map<number, number>();
+  const pending: { id: number; at: number }[] = [];
+  const r: Result = { title: stage.title, goals: [], unfinished: 0, outOfBounds: 0, shakes: 0, shakesWhileMoving: 0 };
+  const stepSec = (STEP_MS / 1000) * timeScale;
+  let t = 0;
+  while (alive.size > 0 && t < MAX_SIM_SEC) {
+    p.step(stepSec);
+    t += stepSec;
+    while (pending.length && pending[0].at <= t) p.removeMarble(pending.shift()!.id);
+    for (const id of alive) {
+      const pos = p.getMarblePosition(id);
+      const prev = last.get(id);
+      if (prev) {
+        const lenSq = (pos.x - prev.x) ** 2 + (pos.y - prev.y) ** 2;
+        // Marble.update 와 같은 정지 판정. 누적은 벽시계(틱당 10ms)
+        if (lenSq < stuckLenSq) {
+          const acc = (stuckMs.get(id) ?? 0) + STEP_MS;
+          if (acc > STUCK_DELAY) {
+            p.shakeMarble(id);
+            r.shakes++;
+            if (Math.sqrt(lenSq) / stepSec >= STUCK_SPEED) r.shakesWhileMoving++;
+            stuckMs.set(id, 0);
+          } else stuckMs.set(id, acc);
+        } else stuckMs.set(id, 0);
+      }
+      last.set(id, { x: pos.x, y: pos.y });
+      if (pos.x < -5 || pos.x > 40) r.outOfBounds++;
+      if (pos.y > stage.goalY) {
+        r.goals.push(t);
+        alive.delete(id);
+        pending.push({ id, at: t + 0.5 });
+      }
+    }
+  }
+  r.unfinished = alive.size;
+  return r;
+}
+
+function maxInWindow(ts: number[], win: number) {
+  let best = 0;
+  for (let i = 0; i < ts.length; i++) {
+    let j = i;
+    while (j < ts.length && ts[j] - ts[i] <= win) j++;
+    best = Math.max(best, j - i);
+  }
+  return best;
+}
+
+async function bench(ns: number[]) {
+  console.log('| 맵 | 구슬 | 첫 골인 | 마지막 골인 | 1초 내 최다 | 5초 내 최다 | 골인 간격 중앙값 | shake | 미완주 |');
+  console.log('|---|---:|---:|---:|---:|---:|---:|---:|---:|');
+  for (let m = 0; m < stages.length; m++) {
+    for (const n of ns) {
+      const r = await simulate({ mapIdx: m, n, timeScale: 1, stuckLenSq: STUCK_LEN_SQ, seed: 1 });
+      const ts = r.goals;
+      const gaps = ts.slice(1).map((v, i) => v - ts[i]).sort((a, b) => a - b);
+      const median = gaps.length ? gaps[Math.floor(gaps.length / 2)] : 0;
+      console.log(
+        `| ${r.title} | ${n} | ${ts[0]?.toFixed(1)}s | ${ts.at(-1)?.toFixed(1)}s | ${maxInWindow(ts, 1)} | ${maxInWindow(ts, 5)} | ${median.toFixed(2)}s | ${r.shakes} | ${r.unfinished}${r.outOfBounds ? ` (이탈 ${r.outOfBounds})` : ''} |`
+      );
+    }
+  }
+}
+
+// 같은 시드·같은 배치에서 정지 판정 문턱만 바꿔 돌린다.
+// timeScale 1 에서는 두 문턱이 같은 값이므로 결과가 완전히 같아야 하고(기존 물리 불변),
+// timeScale 0.2 에서는 기존 문턱이 움직이는 구슬을 튕기는 횟수가 드러나야 한다
+async function stuck(ns: number[]) {
+  console.log(`STUCK_DELAY=${STUCK_DELAY}ms, 정지 속도 기준 ${STUCK_SPEED.toFixed(3)}/s`);
+  console.log('| 맵 | 구슬 | timeScale | shake 기존 → 수정 | 움직이는 중 튕김 기존 → 수정 | 마지막 골인 기존 → 수정 | 미완주 기존 → 수정 |');
+  console.log('|---|---:|---:|---|---|---|---|');
+  for (let m = 0; m < stages.length; m++) {
+    for (const n of ns) {
+      for (const timeScale of [1, 0.2]) {
+        const base = { mapIdx: m, n, timeScale, seed: 1 };
+        const old = await simulate({ ...base, stuckLenSq: STUCK_LEN_SQ });
+        const fixed = await simulate({ ...base, stuckLenSq: STUCK_LEN_SQ * timeScale * timeScale });
+        console.log(
+          `| ${old.title} | ${n} | ${timeScale} | ${old.shakes} → ${fixed.shakes} | ${old.shakesWhileMoving} → ${fixed.shakesWhileMoving} | ${old.goals.at(-1)?.toFixed(1)}s → ${fixed.goals.at(-1)?.toFixed(1)}s | ${old.unfinished} → ${fixed.unfinished} |`
+        );
+      }
+    }
+  }
+}
+
+const [mode = 'bench', arg] = process.argv.slice(2);
+if (mode === 'bench') bench((arg ?? '6,16,30,100,300,1000').split(',').map(Number));
+else if (mode === 'stuck') stuck((arg ?? '6,16,30').split(',').map(Number));
+else console.error('usage: simulate.ts bench [counts] | stuck [counts]');

--- a/src/fastForwader.ts
+++ b/src/fastForwader.ts
@@ -46,8 +46,9 @@ export class FastForwader implements UIObject {
     return this.bound;
   }
 
-  onMouseDown?(_e?: MouseEventArgs): void {
-    this.isEnabled = true;
+  // 영역 밖에서 누르면 mouseHandler 가 undefined 를 넘긴다. 그때도 켜지면 캔버스 어디를 눌러도 2배속이 된다
+  onMouseDown?(e?: MouseEventArgs): void {
+    this.isEnabled = e !== undefined;
   }
 
   onMouseUp?(_e?: MouseEventArgs): void {

--- a/src/marble.ts
+++ b/src/marble.ts
@@ -81,6 +81,9 @@ export class Marble {
   update(deltaTime: number, timeScale: number = 1) {
     const stuckThreshold = 0.00001 * timeScale * timeScale;
     if (this.isActive && Vector.lenSq(Vector.sub(this.lastPosition, this.position)) < stuckThreshold) {
+      // 누적에는 timeScale 을 곱하지 않는다. 이건 화면이 굳는 걸 막는 워치독이라 관객 체감 시간이 기준이다.
+      // 물리 시간으로 바꾸면 슬로모션이 깊을수록 발동이 늦어지는데, 타겟 구슬이 멈추면 _goalDist 가 고정되어
+      // 슬로모션이 풀리지 않으므로 교착을 깨야 할 상황에서 워치독이 오히려 무뎌진다
       this._stuckTime += deltaTime;
 
       if (this._stuckTime > STUCK_DELAY) {

--- a/src/marble.ts
+++ b/src/marble.ts
@@ -72,8 +72,15 @@ export class Marble {
     physics.createMarble(order, 10.25 + (order % 10) * 0.6, maxLine - line + lineDelta);
   }
 
-  update(deltaTime: number) {
-    if (this.isActive && Vector.lenSq(Vector.sub(this.lastPosition, this.position)) < 0.00001) {
+  /**
+   * @param deltaTime 벽시계 기준 경과(ms). 스킬 쿨타임 등 연출 시간에 쓴다
+   * @param timeScale 이 틱에서 물리가 실제로 진행된 비율(슬로모션이면 1 미만).
+   *   정지 판정은 이동 거리로 하므로 물리 시간에 맞춰 문턱을 줄여야 한다. 안 그러면 슬로모션 중
+   *   천천히 구르는 구슬이 멈춘 것으로 오판되어 골인 직전에 랜덤으로 튕겨진다
+   */
+  update(deltaTime: number, timeScale: number = 1) {
+    const stuckThreshold = 0.00001 * timeScale * timeScale;
+    if (this.isActive && Vector.lenSq(Vector.sub(this.lastPosition, this.position)) < stuckThreshold) {
       this._stuckTime += deltaTime;
 
       if (this._stuckTime > STUCK_DELAY) {

--- a/src/roulette.ts
+++ b/src/roulette.ts
@@ -118,11 +118,14 @@ export class Roulette extends EventTarget {
     }
     this._lastTime = currentTime;
 
-    const interval = (this._updateInterval / 1000) * this._timeScale;
+    // _timeScale 은 _updateMarbles 에서 갱신되지만 물리 스텝 크기는 이 프레임 시작값으로 고정된다.
+    // 구슬 정지 판정도 같은 값을 써야 실제 진행된 물리 시간과 맞는다
+    const timeScale = this._timeScale;
+    const interval = (this._updateInterval / 1000) * timeScale;
 
     while (this._elapsed >= this._updateInterval) {
       this.physics.step(interval);
-      this._updateMarbles(this._updateInterval);
+      this._updateMarbles(this._updateInterval, timeScale);
       this._particleManager.update(this._updateInterval);
       this._updateEffects(this._updateInterval);
       this._elapsed -= this._updateInterval;
@@ -146,12 +149,12 @@ export class Roulette extends EventTarget {
     window.requestAnimationFrame(this._update);
   }
 
-  private _updateMarbles(deltaTime: number) {
+  private _updateMarbles(deltaTime: number, timeScale: number) {
     if (!this._stage) return;
 
     for (let i = 0; i < this._marbles.length; i++) {
       const marble = this._marbles[i];
-      marble.update(deltaTime);
+      marble.update(deltaTime, timeScale);
       if (marble.skill === Skills.Impact) {
         this._effects.push(new SkillEffect(marble.x, marble.y));
         this.physics.impact(marble.id);

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,136 @@
   resolved "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.4.tgz"
   integrity sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==
 
+"@esbuild/aix-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz#bf6e10303bcf2e7c686975fa52f937ec2728d8bc"
+  integrity sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==
+
+"@esbuild/android-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz#0c6246bc8d2c4d172aac2db3fb1190d72bd65504"
+  integrity sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==
+
+"@esbuild/android-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.2.tgz#2d84ece6a4e2684d92be26ee13d42757d831c381"
+  integrity sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==
+
+"@esbuild/android-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.2.tgz#fc38d4d6358d8dc1cf53f09f7589fe436eb64801"
+  integrity sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==
+
+"@esbuild/darwin-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz#f83afeeac1d7dac01c7a2fd012b3e451a0591fcc"
+  integrity sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==
+
+"@esbuild/darwin-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz#510147c055a795588dbbe14fd6b1b8ad0a2f30de"
+  integrity sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==
+
+"@esbuild/freebsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz#093b9200ecf0b115ba4e5e248a7485c9c5f8bd5e"
+  integrity sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==
+
+"@esbuild/freebsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz#0be22b6df925d213e841ea87123af5df80b0faf7"
+  integrity sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==
+
+"@esbuild/linux-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz#1bdbc651cda9ba9995c53ed9c71ceaa65094762d"
+  integrity sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==
+
+"@esbuild/linux-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz#beb12ad72b84f72d28488cc1b8ee9f7eb141d753"
+  integrity sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==
+
+"@esbuild/linux-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz#b81f9d55529b45c206a46a138214b1aa6879696b"
+  integrity sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==
+
+"@esbuild/linux-loong64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz#598667241a04c99b76ed6ef940ac50038c419f98"
+  integrity sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==
+
+"@esbuild/linux-mips64el@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz#1c51eb9cea903f53d97b5af3b1841db70f5596ca"
+  integrity sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==
+
+"@esbuild/linux-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz#63dd61f17ceb31a81227f413feac8a71bc2c51f2"
+  integrity sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==
+
+"@esbuild/linux-riscv64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz#3763b08fde5cf25ab1facb8e7752edfe45fbfc27"
+  integrity sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==
+
+"@esbuild/linux-s390x@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz#1a137ff293a82906eb3176385bd7e8e0e5cfb7cb"
+  integrity sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==
+
+"@esbuild/linux-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz#268b36211c146ca54f8fe12c578a8d6ef8979485"
+  integrity sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==
+
+"@esbuild/netbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz#22571ad951d62bb6accc82d8d1fad5c8c1ac0ba1"
+  integrity sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==
+
+"@esbuild/netbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz#42fcc57297eb0a0ca3f5fc475291f4c1a3f7c0de"
+  integrity sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==
+
+"@esbuild/openbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz#9eb32af104ac3dacf4edca01f596664aab0c73ef"
+  integrity sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==
+
+"@esbuild/openbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz#febed2402d6088225e91f20fb4ce2522ad0a4efd"
+  integrity sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==
+
+"@esbuild/openharmony-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz#85641c3d466428bfbccea5f21c26836663fef5ce"
+  integrity sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==
+
+"@esbuild/sunos-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz#a736f9d8962481045fc4c3e54f5479f22c870fb4"
+  integrity sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==
+
+"@esbuild/win32-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz#ee5ab40fad186201b652a33f8a5eb149e9e42532"
+  integrity sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==
+
+"@esbuild/win32-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz#c40d28a6d99a127da6711f2afd74b11cb63b06a7"
+  integrity sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==
+
+"@esbuild/win32-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz#b21affb804cc167c133d95f45b3a1dc1323b9a87"
+  integrity sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==
+
 "@lezer/common@^1.0.0":
   version "1.2.3"
   resolved "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz"
@@ -1102,6 +1232,38 @@ electron-to-chromium@^1.5.263:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz"
   integrity sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==
 
+esbuild@~0.28.0:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.2.tgz#0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+  integrity sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.2"
+    "@esbuild/android-arm" "0.28.2"
+    "@esbuild/android-arm64" "0.28.2"
+    "@esbuild/android-x64" "0.28.2"
+    "@esbuild/darwin-arm64" "0.28.2"
+    "@esbuild/darwin-x64" "0.28.2"
+    "@esbuild/freebsd-arm64" "0.28.2"
+    "@esbuild/freebsd-x64" "0.28.2"
+    "@esbuild/linux-arm" "0.28.2"
+    "@esbuild/linux-arm64" "0.28.2"
+    "@esbuild/linux-ia32" "0.28.2"
+    "@esbuild/linux-loong64" "0.28.2"
+    "@esbuild/linux-mips64el" "0.28.2"
+    "@esbuild/linux-ppc64" "0.28.2"
+    "@esbuild/linux-riscv64" "0.28.2"
+    "@esbuild/linux-s390x" "0.28.2"
+    "@esbuild/linux-x64" "0.28.2"
+    "@esbuild/netbsd-arm64" "0.28.2"
+    "@esbuild/netbsd-x64" "0.28.2"
+    "@esbuild/openbsd-arm64" "0.28.2"
+    "@esbuild/openbsd-x64" "0.28.2"
+    "@esbuild/openharmony-arm64" "0.28.2"
+    "@esbuild/sunos-x64" "0.28.2"
+    "@esbuild/win32-arm64" "0.28.2"
+    "@esbuild/win32-ia32" "0.28.2"
+    "@esbuild/win32-x64" "0.28.2"
+
 escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz"
@@ -1113,6 +1275,11 @@ fill-range@^7.1.1:
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 get-port@^4.2.0:
   version "4.2.0"
@@ -1418,6 +1585,15 @@ tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.23.13:
+  version "4.23.13"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.23.13.tgz#393b8dd813d49e25aed7b1d7cbac6930da49ec08"
+  integrity sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==
+  dependencies:
+    esbuild "~0.28.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 type-fest@^0.20.2:
   version "0.20.2"


### PR DESCRIPTION
어제 회사에서 이걸로 커피 내기를 하다가 구슬이 이상하게 튕기거나 중간에 속도가 달라지면서 터지는 케이스가 보여서, 원인을 좀 찍어보고 PR 올려봅니다. 버그 두 개 고쳤고 확인용 시뮬레이션 스크립트를 같이 넣었습니다. 한번 고려 부탁드립니다.

1. 빨리감기가 캔버스 아무 데나 눌러도 켜집니다.
`mouseHandler`가 영역 밖 클릭이면 `onMouseDown(undefined)`를 호출하는데, `FastForwader`가 인자를 안 보고 무조건 `isEnabled = true`로 만들고 있었습니다. 영역 안일 때만 켜지게 했습니다.

2. 슬로모션 중에 구슬이 멈춘 걸로 잡혀서 튕겨집니다.
`Marble.update`의 정지 판정이 틱당 이동 거리(`lenSq < 1e-5`)인데, 슬로모션에서는 물리가 `timeScale`배만 진행되니까 그냥 천천히 구르는 구슬도 정지로 잡힙니다. 그 상태로 `STUCK_DELAY` 지나면 `shakeMarble`이 랜덤 임펄스를 줘서 골인 직전에 순위가 바뀔 수 있어요. 물리 스텝에 쓴 `timeScale`을 `update`에 같이 넘겨서 거리 문턱을 `timeScale²`로 줄였습니다. 스킬 쿨타임 쪽은 안 건드렸습니다.

기준값 자체는 안 바꿨습니다. 원래 문턱 `lenSq < 1e-5`는 10ms 틱에 0.00316 미만 이동, 즉 속도 약 0.32/s(구슬 지름 0.5 기준 초당 0.6개 정도) 아래를 "멈춤"으로 보는 값이고, 이 속도 기준을 그대로 유지하는 게 목적입니다. 기존 코드는 슬로모션 0.2배에서 물리가 틱당 2ms만 가니까 같은 문턱이 속도 1.6/s로 5배 느슨해졌고, 거리는 timeScale에 비례하니 lenSq에 timeScale²을 곱하면 0.32/s로 돌아옵니다. timeScale이 1인 평소에는 계산이 완전히 동일해서 동작 변화가 없습니다.

## 시뮬레이션

`scripts/simulate.ts`는 렌더링 없이 Box2D만 게임 루프와 같은 10ms 고정 스텝으로 돌립니다. 배치·정지 판정·shake는 `Marble`과 같고 `Math.random`은 시드 고정이라 같은 조건이면 같은 궤적이 나옵니다.

```
npm run simulate -- bench 6,16,30,100,300,1000
npm run simulate -- stuck 6,16,30
```

### 정지 판정 문턱 기존 vs 수정 (`stuck`)

같은 시드·같은 배치에서 문턱만 바꿔 돌렸습니다. "움직이는 중 튕김"은 shake가 발동한 순간 구슬 속도가 0.32/s 이상이었던 횟수, 즉 멈춘 게 아닌데 튕긴 겁니다.

- timeScale 1: 두 문턱이 같은 값이라 결과가 전부 동일합니다. 평소 물리에는 변화가 없다는 확인입니다.
- timeScale 0.2: 기존 문턱은 Pot of greed 30개에서 48번 shake 중 40번이 움직이는 구슬을 튕겼습니다. 수정 후엔 전 맵에서 0이고, Yoru ni Kakeru에서 남은 2~5번은 실제로 멈춘 구슬입니다.

| 맵 | 구슬 | timeScale | shake 기존 → 수정 | 움직이는 중 튕김 기존 → 수정 | 마지막 골인 기존 → 수정 | 미완주 기존 → 수정 |
|---|---:|---:|---|---|---|---|
| Wheel of fortune | 6 | 1 | 0 → 0 | 0 → 0 | 43.5s → 43.5s | 0 → 0 |
| Wheel of fortune | 6 | 0.2 | 0 → 0 | 0 → 0 | 22.9s → 22.9s | 0 → 0 |
| Wheel of fortune | 16 | 1 | 0 → 0 | 0 → 0 | 33.4s → 33.4s | 0 → 0 |
| Wheel of fortune | 16 | 0.2 | 1 → 0 | 1 → 0 | 30.6s → 33.3s | 0 → 0 |
| Wheel of fortune | 30 | 1 | 0 → 0 | 0 → 0 | 46.2s → 46.2s | 0 → 0 |
| Wheel of fortune | 30 | 0.2 | 2 → 0 | 1 → 0 | 41.2s → 43.8s | 0 → 0 |
| BubblePop | 6 | 1 | 0 → 0 | 0 → 0 | 22.4s → 22.4s | 0 → 0 |
| BubblePop | 6 | 0.2 | 0 → 0 | 0 → 0 | 21.9s → 21.9s | 0 → 0 |
| BubblePop | 16 | 1 | 0 → 0 | 0 → 0 | 22.6s → 22.6s | 0 → 0 |
| BubblePop | 16 | 0.2 | 2 → 0 | 1 → 0 | 21.2s → 22.5s | 0 → 0 |
| BubblePop | 30 | 1 | 0 → 0 | 0 → 0 | 21.1s → 21.1s | 0 → 0 |
| BubblePop | 30 | 0.2 | 0 → 0 | 0 → 0 | 23.7s → 23.7s | 0 → 0 |
| Pot of greed | 6 | 1 | 0 → 0 | 0 → 0 | 57.5s → 57.5s | 0 → 0 |
| Pot of greed | 6 | 0.2 | 18 → 0 | 16 → 0 | 105.2s → 35.9s | 0 → 0 |
| Pot of greed | 16 | 1 | 0 → 0 | 0 → 0 | 190.3s → 190.3s | 0 → 0 |
| Pot of greed | 16 | 0.2 | 20 → 0 | 18 → 0 | 103.9s → 123.0s | 0 → 0 |
| Pot of greed | 30 | 1 | 0 → 0 | 0 → 0 | 158.9s → 158.9s | 0 → 0 |
| Pot of greed | 30 | 0.2 | 48 → 0 | 40 → 0 | 200.0s → 92.8s | 0 → 0 |
| Yoru ni Kakeru | 6 | 1 | 0 → 0 | 0 → 0 | 58.5s → 58.5s | 0 → 0 |
| Yoru ni Kakeru | 6 | 0.2 | 16 → 2 | 11 → 0 | 55.9s → 58.6s | 0 → 0 |
| Yoru ni Kakeru | 16 | 1 | 0 → 0 | 0 → 0 | 39.6s → 39.6s | 0 → 0 |
| Yoru ni Kakeru | 16 | 0.2 | 21 → 5 | 18 → 0 | 48.4s → 44.8s | 0 → 0 |
| Yoru ni Kakeru | 30 | 1 | 0 → 0 | 0 → 0 | 43.0s → 43.0s | 0 → 0 |
| Yoru ni Kakeru | 30 | 0.2 | 32 → 5 | 29 → 0 | 43.4s → 41.3s | 0 → 0 |

### 골인 시각 분포 (`bench`, timeScale 1)

이 PR과 직접 관계는 없지만 참고용입니다. 벽 이탈·미완주는 전부 0이고, 물리 자체엔 문제가 없어 보입니다. 구슬이 많을 때 BubblePop·Yoru ni Kakeru에서 골인이 뭉치는 건 맵 특성이고(Yoru는 낙하 속도가 Box2D 스텝당 이동 한계에 걸려 다 같은 종단속도로 떨어짐), Wheel of fortune 1000개에서 shake가 2천 번 넘게 나오는 건 출발 통로에 쌓인 구슬이 정지로 잡히는 거라 의도된 동작으로 보입니다.

| 맵 | 구슬 | 첫 골인 | 마지막 골인 | 1초 내 최다 | 5초 내 최다 | 골인 간격 중앙값 | shake | 미완주 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| Wheel of fortune | 6 | 12.6s | 43.5s | 2 | 2 | 5.11s | 0 | 0 |
| Wheel of fortune | 16 | 14.5s | 33.4s | 6 | 10 | 0.22s | 0 | 0 |
| Wheel of fortune | 30 | 12.0s | 46.2s | 4 | 7 | 0.50s | 0 | 0 |
| Wheel of fortune | 100 | 10.0s | 106.6s | 6 | 9 | 0.26s | 0 | 0 |
| Wheel of fortune | 300 | 9.8s | 240.2s | 6 | 12 | 0.25s | 0 | 0 |
| Wheel of fortune | 1000 | 11.7s | 669.0s | 8 | 15 | 0.20s | 2056 | 0 |
| BubblePop | 6 | 19.1s | 22.4s | 3 | 6 | 0.28s | 0 | 0 |
| BubblePop | 16 | 17.5s | 22.6s | 6 | 15 | 0.13s | 0 | 0 |
| BubblePop | 30 | 16.1s | 21.1s | 10 | 29 | 0.13s | 0 | 0 |
| BubblePop | 100 | 14.4s | 65.8s | 12 | 46 | 0.13s | 37 | 0 |
| BubblePop | 300 | 14.9s | 147.8s | 14 | 34 | 0.11s | 95 | 0 |
| BubblePop | 1000 | 14.3s | 220.9s | 19 | 53 | 0.08s | 96 | 0 |
| Pot of greed | 6 | 7.6s | 57.5s | 1 | 1 | 11.48s | 0 | 0 |
| Pot of greed | 16 | 7.0s | 190.3s | 2 | 4 | 2.35s | 0 | 0 |
| Pot of greed | 30 | 4.8s | 158.9s | 9 | 11 | 1.07s | 0 | 0 |
| Pot of greed | 100 | 5.8s | 126.7s | 19 | 45 | 0.20s | 0 | 0 |
| Pot of greed | 300 | 5.3s | 236.6s | 41 | 131 | 0.05s | 0 | 0 |
| Pot of greed | 1000 | 5.3s | 267.1s | 59 | 215 | 0.03s | 6 | 0 |
| Yoru ni Kakeru | 6 | 38.7s | 58.5s | 2 | 4 | 1.90s | 0 | 0 |
| Yoru ni Kakeru | 16 | 28.4s | 39.6s | 6 | 11 | 0.26s | 0 | 0 |
| Yoru ni Kakeru | 30 | 22.7s | 43.0s | 7 | 16 | 0.44s | 0 | 0 |
| Yoru ni Kakeru | 100 | 18.6s | 36.0s | 19 | 55 | 0.07s | 0 | 0 |
| Yoru ni Kakeru | 300 | 18.2s | 39.0s | 64 | 167 | 0.01s | 0 | 0 |
| Yoru ni Kakeru | 1000 | 17.7s | 64.4s | 140 | 431 | 0.01s | 3 | 0 |

tsc, biome 돌려봤고 이 변경으로 새로 생긴 에러는 없습니다. (`roulette.ts`의 possibly undefined 하나랑 `marble.ts` 포맷 하나는 원래 있던 거라 그대로 뒀습니다)

🤖 Generated with [Claude Code](https://claude.com/claude-code)